### PR TITLE
Add 'enter-admin-container' to easily enable and enter admin container

### DIFF
--- a/enable-admin-container
+++ b/enable-admin-container
@@ -5,11 +5,6 @@
 
 error() {
    echo -e "Error: ${*}\n" >&2
-   cat >&2 <<-EOF
-	You can manually enable the admin container like this:
-	   apiclient -u /settings -m PATCH -d '{"host-containers": {"admin": {"enabled": true}}}'
-	   apiclient -u /tx/commit_and_apply -m POST
-	EOF
    exit 1
 }
 
@@ -17,17 +12,9 @@ if ! command -v apiclient >/dev/null 2>&1; then
    error "can't find 'apiclient'"
 fi
 
-# Use our own transaction so we don't interfere with other changes
-TX="enable-admin-container"
-
-echo "Setting admin container to enabled"
-if ! apiclient -v -u "/settings?tx=${TX}" -m PATCH -d '{"host-containers": {"admin": {"enabled": true}}}'; then
-   error "failed to change enabled setting of admin container"
-fi
-
-echo "Committing and applying changes"
-if ! apiclient -v -u "/tx/commit_and_apply?tx=${TX}" -m POST; then
-   error "failed to commit and apply settings"
+echo "Enabling admin container"
+if ! apiclient set host-containers.admin.enabled=true; then
+   error "failed to enable admin container"
 fi
 
 echo "The admin container is now enabled - it should pull and start soon, and then you can SSH in"

--- a/enable-admin-container
+++ b/enable-admin-container
@@ -15,12 +15,14 @@ fi
 # Check if the admin container is already enabled; if it is, we don't want to
 # change settings, or it may be restarted.
 if apiclient raw -u "/settings?keys=settings.host-containers.admin.enabled" | grep -q true; then
-   echo "The admin container is already enabled - it should start soon, if it hasn't already, and then you can SSH in."
+   echo "The admin container is already enabled - it should start soon, if it hasn't already, and then you can SSH in or use 'apiclient exec admin bash'."
+   echo "You can also use 'enter-admin-container' to enable, wait, and connect in one step."
 else
    echo "Enabling admin container"
    if ! apiclient set host-containers.admin.enabled=true; then
       error "failed to enable admin container"
    fi
 
-   echo "The admin container is now enabled - it should pull and start soon, and then you can SSH in."
+   echo "The admin container is now enabled - it should pull and start soon, and then you can SSH in or use 'apiclient exec admin bash'."
+   echo "You can also use 'enter-admin-container' to enable, wait, and connect in one step."
 fi

--- a/enable-admin-container
+++ b/enable-admin-container
@@ -12,9 +12,15 @@ if ! command -v apiclient >/dev/null 2>&1; then
    error "can't find 'apiclient'"
 fi
 
-echo "Enabling admin container"
-if ! apiclient set host-containers.admin.enabled=true; then
-   error "failed to enable admin container"
-fi
+# Check if the admin container is already enabled; if it is, we don't want to
+# change settings, or it may be restarted.
+if apiclient raw -u "/settings?keys=settings.host-containers.admin.enabled" | grep -q true; then
+   echo "The admin container is already enabled - it should start soon, if it hasn't already, and then you can SSH in."
+else
+   echo "Enabling admin container"
+   if ! apiclient set host-containers.admin.enabled=true; then
+      error "failed to enable admin container"
+   fi
 
-echo "The admin container is now enabled - it should pull and start soon, and then you can SSH in"
+   echo "The admin container is now enabled - it should pull and start soon, and then you can SSH in."
+fi

--- a/enter-admin-container
+++ b/enter-admin-container
@@ -1,0 +1,45 @@
+#!/bin/bash
+# This file is part of Bottlerocket.
+# Copyright Amazon.com, Inc., its affiliates, or other contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+THISDIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+error() {
+   echo -e "Error: ${*}\n" >&2
+   exit 1
+}
+
+if ! command -v apiclient >/dev/null 2>&1; then
+   error "can't find 'apiclient'"
+fi
+
+# Use our existing script to enable the admin container if it's not already.
+# We don't want its stdout, which is about how to connect to the admin
+# container; that's what this script is for!
+echo "Confirming admin container is enabled..."
+if ! "${THISDIR}/enable-admin-container" >/dev/null; then
+   error "failed to enable admin container."
+fi
+
+echo -n "Waiting for admin container to start..."
+max=60
+i=0
+while :; do
+   (( i++ ))
+   if [[ $i -gt $max ]]; then
+      echo
+      error "could not connect to admin container within $max seconds."
+   fi
+
+   if apiclient exec admin true &>/dev/null; then
+      break
+   fi
+
+   echo -n "."
+   sleep 1
+done
+echo
+
+echo "Entering admin container"
+apiclient exec admin bash

--- a/motd
+++ b/motd
@@ -10,11 +10,14 @@ You can run `apiclient --help` for usage details, and check the main
 Bottlerocket documentation for descriptions of all settings and examples of
 changing them.
 
-If you need to debug the system further, you can enable the admin container.
-This enables SSH access to the system using the key you specified when you
-launched the instance.  This environment has more debugging tools installed,
-and allows you to get root access to the host.
+If you need to debug the system further, you can use the admin container.  The
+admin container has more debugging tools installed and allows you to get root
+access to the host.  The easiest way to get started is like this, which enables
+and enters the admin container using apiclient:
 
-To enable the admin container, run:
+   enter-admin-container
+
+You can also access the admin container through SSH if you have network access.
+Just enable the container like this, then SSH to the host:
 
    enable-admin-container


### PR DESCRIPTION
**Description of changes:**

```
d54e5ec enable-admin-container: use 'apiclient set'
17d4a7a enable-admin-container: only set if not already
    Changing the setting restarts services, which is unnecessary if it's
    already enabled, and restarting services disconnects existing users of
    the admin container.
f5de0a2 Add 'enter-admin-container' to easily enable and enter admin container
```

This is based on the new `apiclient exec` from https://github.com/bottlerocket-os/bottlerocket/pull/1802, which allows people to enter the admin container without SSH; this PR makes that easier to use from the control container.

**Testing done:**

Tested the `enable-admin-container` changes first:
* If it's not already enabled, it does so.
* If it's already enabled, it doesn't!  No more disconnections!

Then `enter-admin-container`:
* If it's not already enabled, it uses `enable-admin-container` correctly, then enters.
* If it's already enabled, it enters quickly.

Also confirmed that it dies and messages as expected if it takes too long for the admin container to start, along with a bunch of improbable error cases found before the code was clean.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
