### PR TITLE
Run yum update during Docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN \
   curl -L "https://s3.eu-north-1.amazonaws.com/amazon-ssm-eu-north-1/${SSM_AGENT_VERSION}/linux_${ARCH}/amazon-ssm-agent.rpm" \
        -o "amazon-ssm-agent-${SSM_AGENT_VERSION}.${ARCH}.rpm" && \
   grep "amazon-ssm-agent-${SSM_AGENT_VERSION}.${ARCH}.rpm" hashes | sha512sum --check - && \
-  yum install -y "amazon-ssm-agent-${SSM_AGENT_VERSION}.${ARCH}.rpm" shadow-utils jq && \
+  yum -y update && yum install -y "amazon-ssm-agent-${SSM_AGENT_VERSION}.${ARCH}.rpm" shadow-utils jq && \
   rm "amazon-ssm-agent-${SSM_AGENT_VERSION}.${ARCH}.rpm" && \
   rm -rf /var/cache/yum ./hashes && \
   rmdir /var/lib/amazon/ssm && \


### PR DESCRIPTION
**Description of changes:**
This performs a `yum update` of the underlying Amazon Linux container prior to building the control container.


**Testing done:**
* Confirmed that the build successfully performs a yum update prior to building the rest of the image.
* Pushed a build of the container to an ECR repository and overrode it on a bottlerocket instance. Ensured SSM control was still functional.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
