### PR TITLE
Add 'enter-admin-container' to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,9 @@ ADD ./bashrc /etc/skel/.bashrc
 # ENV environment variable.  Point it to our bashrc, which just prints motd.
 ENV ENV /etc/skel/.bashrc
 
-# Add our helper to quickly enable the admin container.
-ADD ./enable-admin-container /usr/bin/
-RUN chmod +x /usr/bin/enable-admin-container
+# Add our helpers to quickly interact with the admin container.
+ADD ./enable-admin-container ./enter-admin-container /usr/bin/
+RUN chmod +x /usr/bin/enable-admin-container /usr/bin/enter-admin-container
 
 # Create our user in the group that allows API access.
 RUN groupadd -g 274 api


### PR DESCRIPTION
**Description of changes:**

This adds `enter-admin-container`(https://github.com/bottlerocket-os/bottlerocket-control-container/pull/18) to `/usr/bin` in the control container.

**Testing done:**

Launched bottlerocket instance and used `enter-admin-container` to interact with the admin container.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
