### PR TITLE
Various housekeeping changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-# DOCKER_ARCH is the multiarch variant that is used as the base image.
-ARG DOCKER_ARCH
-FROM $DOCKER_ARCH/amazonlinux:2
+FROM amazonlinux:2
 
 # IMAGE_VERSION is the assigned version of inputs for this image.
 ARG IMAGE_VERSION
@@ -8,14 +6,10 @@ ENV IMAGE_VERSION=$IMAGE_VERSION
 # IMAGE_VERSION is the assigned version of inputs for this image.
 ARG SSM_AGENT_VERSION
 ENV SSM_AGENT_VERSION=$SSM_AGENT_VERSION
-# ARCH is the normative target architecture for the image.
-ARG ARCH
-ENV ARCH=$ARCH
 
 # Validation
 RUN : \
     "${IMAGE_VERSION:?IMAGE_VERSION is required to build}" \
-    "${ARCH:?ARCH is required to build}" \
     "${SSM_AGENT_VERSION:?SSM Agent version required to build}"
 
 LABEL "org.opencontainers.image.version"="$IMAGE_VERSION"
@@ -26,6 +20,7 @@ LABEL "org.opencontainers.image.version"="$IMAGE_VERSION"
 # SSM Agent is downloaded from eu-north-1 as this region gets new releases of SSM Agent first.
 COPY ./hashes/ssm ./hashes
 RUN \
+  ARCH=$(uname -m | sed 's/aarch64/arm64/' | sed 's/x86_64/amd64/') && \
   curl -L "https://s3.eu-north-1.amazonaws.com/amazon-ssm-eu-north-1/${SSM_AGENT_VERSION}/linux_${ARCH}/amazon-ssm-agent.rpm" \
        -o "amazon-ssm-agent-${SSM_AGENT_VERSION}.${ARCH}.rpm" && \
   grep "amazon-ssm-agent-${SSM_AGENT_VERSION}.${ARCH}.rpm" hashes | sha512sum --check - && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 
 # IMAGE_VERSION is the assigned version of inputs for this image.
 ARG IMAGE_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,9 @@ RUN \
 # Add motd explaining the control container.
 RUN rm -f /etc/motd /etc/issue
 COPY --chown=root:root motd /etc/
+# Add custom PS1 to show you are in the control container.
+ARG CUSTOM_PS1='[\u@control]\$ '
+RUN echo "PS1='$CUSTOM_PS1'" > "/etc/profile.d/bottlerocket-ps1.sh"
 # Add bashrc that shows the motd.
 COPY ./bashrc /etc/skel/.bashrc
 # SSM starts sessions with 'sh', not 'bash', which for us is a link to bash.

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,9 @@ RUN \
 
 # Add motd explaining the control container.
 RUN rm -f /etc/motd /etc/issue
-ADD --chown=root:root motd /etc/
+COPY --chown=root:root motd /etc/
 # Add bashrc that shows the motd.
-ADD ./bashrc /etc/skel/.bashrc
+COPY ./bashrc /etc/skel/.bashrc
 # SSM starts sessions with 'sh', not 'bash', which for us is a link to bash.
 # Furthermore, it starts sh as an interactive shell, but not a login shell.
 # In this mode, the only startup file respected is the one pointed to by the
@@ -42,7 +42,7 @@ ADD ./bashrc /etc/skel/.bashrc
 ENV ENV /etc/skel/.bashrc
 
 # Add our helpers to quickly interact with the admin container.
-ADD --chmod=755 \
+COPY --chmod=755 \
   ./disable-admin-container \
   ./enable-admin-container \
   ./enter-admin-container \
@@ -52,5 +52,5 @@ ADD --chmod=755 \
 RUN groupadd -g 274 api
 RUN useradd -m -G users,api ssm-user
 
-ADD --chmod=755 start_control_ssm.sh /usr/sbin/
+COPY --chmod=755 start_control_ssm.sh /usr/sbin/
 CMD ["/usr/sbin/start_control_ssm.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,20 +42,15 @@ ADD ./bashrc /etc/skel/.bashrc
 ENV ENV /etc/skel/.bashrc
 
 # Add our helpers to quickly interact with the admin container.
-ADD \
+ADD --chmod=755 \
   ./disable-admin-container \
   ./enable-admin-container \
   ./enter-admin-container \
   /usr/bin/
-RUN chmod +x \
-  /usr/bin/disable-admin-container \
-  /usr/bin/enable-admin-container \
-  /usr/bin/enter-admin-container
 
 # Create our user in the group that allows API access.
 RUN groupadd -g 274 api
 RUN useradd -m -G users,api ssm-user
 
-ADD start_control_ssm.sh /usr/sbin/
-RUN chmod +x /usr/sbin/start_control_ssm.sh
+ADD --chmod=755 start_control_ssm.sh /usr/sbin/
 CMD ["/usr/sbin/start_control_ssm.sh"]

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ dist: all
 
 # Build the container image.
 build:
-	docker build \
+	DOCKER_BUILDKIT=1 docker build \
 		--tag $(IMAGE_NAME) \
 		--build-arg IMAGE_VERSION="$(IMAGE_VERSION)" \
 		--build-arg SSM_AGENT_VERSION="$(SSM_AGENT_VERSION)" \

--- a/Makefile
+++ b/Makefile
@@ -13,16 +13,8 @@ DESTDIR ?= .
 # tarball.
 DISTFILE ?= $(subst /,,$(DESTDIR))/$(subst /,_,$(IMAGE_NAME)).tar.gz
 
-# These values derive ARCH and DOCKER_ARCH which are needed by dependencies in
-# image build defaulting to system's architecture when not specified.
-#
-# UNAME_ARCH is the runtime architecture of the building host.
 UNAME_ARCH = $(shell uname -m)
-# ARCH is the target architecture which is being built for.
 ARCH ?= $(lastword $(subst :, ,$(filter $(UNAME_ARCH):%,x86_64:amd64 aarch64:arm64)))
-# DOCKER_ARCH is the docker specific architecture specifier used for building on
-# multiarch container images.
-DOCKER_ARCH ?= $(lastword $(subst :, ,$(filter $(ARCH):%,amd64:amd64 arm64:arm64v8)))
 
 # SSM_AGENT_VERSION is the SSM Agent's distributed RPM Version to install.
 SSM_AGENT_VERSION ?= 3.1.821.0
@@ -42,8 +34,6 @@ build:
 	docker build \
 		--tag $(IMAGE_NAME) \
 		--build-arg IMAGE_VERSION="$(IMAGE_VERSION)" \
-		--build-arg ARCH="$(ARCH)" \
-		--build-arg DOCKER_ARCH="$(DOCKER_ARCH)" \
 		--build-arg SSM_AGENT_VERSION="$(SSM_AGENT_VERSION)" \
 		-f Dockerfile . >&2
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ For more information about the control container, including how to use it and ho
 
 ## Building the Container Image
 
-You'll need Docker 17.06.2 or later, for multi-stage build support.
+You'll need Docker 20.10 or later for multi-stage build, BuildKit, and chmod on COPY/ADD support.
 Then run `make`!
 
 ## Connecting to AWS Systems Manager (SSM)


### PR DESCRIPTION
**Issue number:**

#16

**Description of changes:**

This PR contains a couple small changes:
- Fix multi-arch builds by removing **ARCH**/**DOCKER_ARCH** build arguments.
(thus making the container compatible with `buildx --platform linux/<arch>`)
- Pull base images from Amazon ECR Public.
- Replace `RUN chmod +x` with **ADD**/**COPY** `--chmod 755`.
- Replace unnecessary **ADD**s with **COPY**s.
- Set a custom PS1 to show that you are in the control container.

**Testing done:**

- Launched `aws-ecs-1` ami with new control container set in userdata.
- Enabled the admin container via the control container's APIclient.
- Verified APIclient Exec functionality.
- Verified Bottlerocket access via `sudo sheltie`.
- Connected to admin container via ec2 instance connect.

**Additional testing done:**

- [x] Build with `buildx` using `--platform linux/amd64`
- [x] Build with `buildx` using `--platform linux/arm64`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
