### PR TITLE
Add `script` binary and `screen` to container

### DIFF
--- a/hashes/util-linux
+++ b/hashes/util-linux
@@ -1,0 +1,2 @@
+# https://www.kernel.org/pub/linux/utils/util-linux/v2.37/util-linux-2.37.4.tar.xz
+SHA512 (util-linux-2.37.4.tar.xz) = ada2629b0a8e83ea83513e04f7b1ccceb3b8ab82acd119c5d8389d1abc48c92d0b591f39fb34b1fd65db3ab630f03a672a9f3dacf1a6e4f124bdb083fc1be6d7

--- a/sdk-fetch
+++ b/sdk-fetch
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euxo pipefail
+# shellcheck disable=SC2046
+curl --fail --remote-name-all --remote-time \
+    $(awk -F '[ ()]' '/^SHA512 \(/ {
+        printf "https://cache.bottlerocket.aws/%s/%s/%s\n", $3, $6, $3
+    }' "$1")
+sha512sum --check "$1"


### PR DESCRIPTION
**Issue number:**

#24

**Description of changes:**

`script` is a script utility in the `util-linux` package that the SSM
agent uses for session logging when enabled. `screen` is also installed
to avoid log data from being truncated (per [Logging session activity](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-logging.html)).

**Testing done:**

- Launched `aws-ecs-1` ami with new control container set in userdata.
- Enabled the admin container via the control container's APIclient.
- Verified APIclient Exec functionality.
- Verified Bottlerocket access via `sudo sheltie`.
- Connected to admin container via ec2 instance connect.

**Additional testing done:**

Confirmed that session logging to S3 bucket works. (thanks, @etungsten!)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
