### PR TITLE
Add licenses for `script`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,12 @@ RUN \
     || { cat config.log; exit 1; }
 RUN make -j`nproc` script
 RUN cp script /opt/script
+RUN \
+  mkdir -p /usr/share/licenses/util-linux && cp -p \
+      Documentation/licenses/COPYING.BSD-4-Clause-UC \
+      Documentation/licenses/COPYING.GPL-2.0-or-later \
+      Documentation/licenses/COPYING.LGPL-2.1-or-later \
+    /usr/share/licenses/util-linux
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2
 
@@ -43,6 +49,7 @@ RUN : \
 LABEL "org.opencontainers.image.version"="$IMAGE_VERSION"
 
 COPY --from=builder /opt/script /usr/bin/
+COPY --from=builder /usr/share/licenses/util-linux /usr/share/licenses/util-linux
 # Validate script binary
 RUN /usr/bin/script &>/dev/null
 


### PR DESCRIPTION
**Description of changes:**

_Companion PR to #27_

Adds licenses for the `script` binary to `/usr/share/licenses/util-linux`.


**Testing done:**

- Launched `aws-ecs-1` ami with new control container set in userdata.
- Enabled the admin container via the control container's APIclient.
- Verified APIclient Exec functionality.
- Verified the licenses were available in `/usr/share/licenses/util-linux`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
