### PR TITLE
Move SSM agent install to own line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,8 @@ RUN \
   curl -L "https://s3.eu-north-1.amazonaws.com/amazon-ssm-eu-north-1/${SSM_AGENT_VERSION}/linux_${ARCH}/amazon-ssm-agent.rpm" \
        -o "amazon-ssm-agent-${SSM_AGENT_VERSION}.${ARCH}.rpm" && \
   grep "amazon-ssm-agent-${SSM_AGENT_VERSION}.${ARCH}.rpm" hashes | sha512sum --check - && \
-  yum -y update && yum install -y "amazon-ssm-agent-${SSM_AGENT_VERSION}.${ARCH}.rpm" shadow-utils jq screen && \
+  yum update -y && yum install -y jq screen shadow-utils && \
+  yum install -y "amazon-ssm-agent-${SSM_AGENT_VERSION}.${ARCH}.rpm" && \
   rm "amazon-ssm-agent-${SSM_AGENT_VERSION}.${ARCH}.rpm" && \
   rm -rf /var/cache/yum ./hashes && \
   rmdir /var/lib/amazon/ssm && \


### PR DESCRIPTION
**Description of changes:**

In the unlikely scenario that the downloaded RPM is not compatible, it may be skipped without triggering an error for the build _(when installing the agent along with other packages)_. When on its own line, an install error will cause the build to fail.

**Testing done:**

Manually set **ARCH** on L62 to `amd64` for an `arm64` container image and the build failed with the following error: 
```
#21 16.24 Cannot add package amazon-ssm-agent-3.1.821.0.amd64.rpm to transaction. Not a compatible architecture: x86_64
#21 16.24 Error: Nothing to do
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
