### PR TITLE
Fix build hang during test of `script`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN ln -s /opt/util-linux/bin/* /usr/bin
 # Validate lscpu binary
 RUN /usr/bin/lscpu &>/dev/null
 # Validate script binary
-RUN /usr/bin/script &>/dev/null
+RUN /usr/bin/script --version &>/dev/null
 
 # Install the arch specific build of SSM agent *and confirm that it installed* -
 # yum will allow architecture-mismatched packages to not install and consider

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ dist: all
 
 # Build the container image.
 build:
-	DOCKER_BUILDKIT=1 docker build \
+	DOCKER_BUILDKIT=1 docker build $(DOCKER_BUILD_FLAGS) \
 		--tag $(IMAGE_NAME) \
 		--build-arg IMAGE_VERSION="$(IMAGE_VERSION)" \
 		--build-arg SSM_AGENT_VERSION="$(SSM_AGENT_VERSION)" \


### PR DESCRIPTION
**Issue number:** n/a

**Description of changes:** I carried this change over from the cancelled #45. The build test step for the custom built `script` utility required a change now not to hang. I have not fully tracked down what is happening yet. Somewhat awkwardly, looking at it with fresh eyes I couldn't explain why that worked before. More details in the commit message. Since writing the commit message I also tested for differences in the kernel version (wondering whether line discipline changes may be involved in (not) sending EOT/^D), to no avail. Hence, the currently quite vague state is "my x86_64 machine hangs, my aarch64 machine works". This only bothers my curiosity; the proposed fix itself is reasonable on its own.

If anyone else wants to test the build process, please report back. Some more observations: `echo | script` reliably terminates, `echo -n | script` (without a newline) does not.

**Testing done:**

On both x86_64 and aarch64:

* [x] Node associates with SSM, reports agent version
* [x] SSM agent reports software inventory
* [x] Can start an interactive SSM session
* [x] Build testing

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
