### PR TITLE
Improved `check-ssm-agent`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,23 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2 as builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
 
 # Install build dependencies for the package(s) below
 RUN \
   yum -y install \
-    autoconf automake bison gettext-devel libtool make pkgconfig tar xz
+    autoconf \
+    automake \
+    bison \
+    gettext-devel \
+    libtool \
+    make \
+    pkgconfig \
+    tar \
+    xz
 COPY ./sdk-fetch /usr/local/bin
 
 ARG utillinux_version=2.38.1
+ENV utillinux_version=$utillinux_version
+
+ENV HOME=/root
 
 WORKDIR ${HOME}/build
 COPY ./hashes/util-linux ./hashes
@@ -42,10 +53,11 @@ RUN \
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2
 
-# IMAGE_VERSION is the assigned version of inputs for this image.
+# IMAGE_VERSION is the assigned version from input for this image.
 ARG IMAGE_VERSION
 ENV IMAGE_VERSION=$IMAGE_VERSION
-# IMAGE_VERSION is the assigned version of inputs for this image.
+
+# SSM_AGENT_VERSION is the assigned agent version from input for this image.
 ARG SSM_AGENT_VERSION
 ENV SSM_AGENT_VERSION=$SSM_AGENT_VERSION
 
@@ -105,7 +117,7 @@ COPY ./bashrc /etc/skel/.bashrc
 # Furthermore, it starts sh as an interactive shell, but not a login shell.
 # In this mode, the only startup file respected is the one pointed to by the
 # ENV environment variable.  Point it to our bashrc, which just prints motd.
-ENV ENV /etc/skel/.bashrc
+ENV ENV=/etc/skel/.bashrc
 
 # Add our helpers to quickly interact with the admin container.
 COPY --chmod=755 \

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,10 @@ check: check-ssm-agent
 
 # Check that the SSM Agent is the expected version.
 check-ssm-agent:
-	docker run --rm --entrypoint /usr/bin/bash \
+	@echo "Running SSM version check"
+	@docker run --rm --entrypoint /usr/bin/bash \
 		$(IMAGE_NAME) \
-		-c 'rpm -q amazon-ssm-agent --queryformat "%{version}\n" | grep -qFw "$(SSM_AGENT_VERSION)"' >&2
+		-c 'amazon-ssm-agent -version | grep -Fw "$(SSM_AGENT_VERSION)"' >&2
 
 # Download SSM Agent version SSM_AGENT_VERSION for all architectures.
 download-ssm-agent: amazon-ssm-agent-${SSM_AGENT_VERSION}.amd64.rpm amazon-ssm-agent-${SSM_AGENT_VERSION}.arm64.rpm


### PR DESCRIPTION
**Description of changes:**

Check the version of amazon-ssm-agent directly and print to the build output.

Also addressed lints from `docker-language-server`.

**Testing done:**

`make` 
```bash
Running SSM version check
SSM Agent version: 3.3.1957.0
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
