### PR TITLE
fix: replace dnf update with dnf upgrade --releasever=latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS builder
 
-RUN dnf install -y \
+RUN dnf upgrade -y --releasever=latest && \
+    dnf install -y \
     'dnf-command(download)' \
     cpio
 
@@ -31,7 +32,7 @@ LABEL "org.opencontainers.image.version"="$IMAGE_VERSION"
 # SSM Agent is downloaded from eu-north-1 as this region gets new releases of SSM Agent first.
 COPY ./hashes/ssm ./hashes
 COPY ./gpg-keys/amazon-ssm-agent.gpg ./amazon-ssm-agent.gpg
-RUN dnf update -y && \
+RUN dnf upgrade -y --releasever=latest && \
     dnf install -y \
         crypto-policies-scripts \
         jq \


### PR DESCRIPTION
**Description of changes:**

AL2023 base container images are pinned to a specific release version for reproducibility. A plain `dnf upgrade` will only pull packages from that pinned release, which defeats the purpose of updating to the latest available patches.

`--releasever=latest` overrides the version lock and tells `dnf` to fetch from the latest AL2023 release repositories, which is the equivalent behavior to what `yum update` gave us on AL2.

**Testing done:**

`make`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
